### PR TITLE
fix(auth): send Client-ID header on all Twitch API requests (#550)

### DIFF
--- a/lib/login/index.js
+++ b/lib/login/index.js
@@ -57,6 +57,7 @@ if (config.login.twitch && config.login.twitch.enabled) {
 				clientSecret: config.login.twitch.clientSecret,
 				callbackURL: `${protocol}://${config.baseURL}/login/auth/twitch`,
 				scope,
+				customHeaders: {'Client-ID': config.login.twitch.clientID}
 			},
 			(accessToken, refreshToken, profile, done) => {
 				profile.allowed = config.login.twitch.allowedUsernames.indexOf(profile.username) > -1;


### PR DESCRIPTION
As of now, Twitch requires this header on all Helix endpoints.
Recover of the Twitch Login Fix